### PR TITLE
Enhancement: extend `getCountryFromAccount` to also use `.countryISO`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencollective/taxes",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Helpers to calculate taxes on Open Collective",
   "main": "dist/index.js",
   "scripts": {

--- a/src/types/Accounts.ts
+++ b/src/types/Accounts.ts
@@ -1,5 +1,6 @@
 export type Account = {
   settings?: Record<string, unknown>;
+  countryISO?: string;
   location?: {
     country: string;
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,11 @@ export const getCountryFromAccount = (account: Record<string, any> | null): stri
   }
 
   return (
-    ((get(account.location, 'country') ||
+    ((get(account, 'countryISO') ||
+      get(account.location, 'country') ||
+      get(account.parent, 'countryISO') || 
       get(account.parent, 'location.country') ||
+      get(account.parentCollective, 'countryISO') ||
       get(account.parentCollective, 'location.country')) as string) || null
   );
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ export const getCountryFromAccount = (account: Record<string, any> | null): stri
   return (
     ((get(account, 'countryISO') ||
       get(account.location, 'country') ||
-      get(account.parent, 'countryISO') || 
+      get(account.parent, 'countryISO') ||
       get(account.parent, 'location.country') ||
       get(account.parentCollective, 'countryISO') ||
       get(account.parentCollective, 'location.country')) as string) || null

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,7 @@ describe('getApplicableTaxes', () => {
       getApplicableTaxes(
         {
           settings: { VAT: { type: 'OWN' } },
-          location: { country: 'FR' },
+          countryISO: 'FR',
         },
         null,
         TierType.PRODUCT,
@@ -26,7 +26,7 @@ describe('getApplicableTaxes', () => {
         },
         {
           settings: { VAT: { type: 'OWN' } },
-          location: { country: 'FR' },
+          countryISO: 'FR',
         },
         TierType.PRODUCT,
       ),
@@ -39,7 +39,7 @@ describe('getApplicableTaxes', () => {
         {},
         {
           settings: { GST: {} },
-          location: { country: 'NZ' },
+          countryISO: 'NZ',
         },
         TierType.PRODUCT,
       ),


### PR DESCRIPTION
This PR extends `getCountryFromAccount` to also look in `.countryISO`. 

This is needed for https://github.com/opencollective/opencollective-api/pull/8626 when `.location` on Collectives becomes an associated model so is not loaded by default. However, `.countryISO` remains on the Collective model (note: also saved in the Location model)